### PR TITLE
feat: #97 Improve index performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,8 @@
         "ts-jest": "^29.0.1",
         "typed-redux-saga": "^1.5.0",
         "typescript-fsa": "^3.0.0",
-        "typescript-fsa-reducers": "^1.2.2"
+        "typescript-fsa-reducers": "^1.2.2",
+        "virtua": "^0.20.5"
       },
       "devDependencies": {
         "@jambit/eslint-plugin-typed-redux-saga": "^0.4.0",
@@ -14810,6 +14811,27 @@
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/virtua": {
+      "version": "0.20.5",
+      "resolved": "https://registry.npmjs.org/virtua/-/virtua-0.20.5.tgz",
+      "integrity": "sha512-GHL+kSTotf5L1x3/Wcir0KkNKxmQIdWiDrcrBNz+DMiLUdNtskKs+E76Z0SSeeL0+I/PFutBrI8fXw/j7N+6sQ==",
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0",
+        "vue": ">=3.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
     },
     "node_modules/walker": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     "ts-jest": "^29.0.1",
     "typed-redux-saga": "^1.5.0",
     "typescript-fsa": "^3.0.0",
-    "typescript-fsa-reducers": "^1.2.2"
+    "typescript-fsa-reducers": "^1.2.2",
+    "virtua": "^0.20.5"
   },
   "devDependencies": {
     "@jambit/eslint-plugin-typed-redux-saga": "^0.4.0",

--- a/src/renderer/components/PrimarySidebar.tsx
+++ b/src/renderer/components/PrimarySidebar.tsx
@@ -2,6 +2,7 @@ import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { VList } from 'virtua';
 
 import SearchProperties from '../../common/SearchProperties';
 import { Mediator } from '../Mediator';
@@ -62,10 +63,10 @@ function Index(): JSX.Element {
   const { editable } = book;
 
   return (
-    <>
+    <VList>
       {editable &&
         (templates ?? []).map(template => (
-          <li key={template.id} className={theme.style['Index.li']}>
+          <div key={template.id} className={theme.style['Index.li']}>
             <button
               className={theme.style['Index.button']}
               onClick={async () => {
@@ -76,10 +77,10 @@ function Index(): JSX.Element {
               <AddIcon fontSize="small" />
               {template.name}
             </button>
-          </li>
+          </div>
         ))}
       {(mediators ?? []).map(mediator => (
-        <li key={mediator.summary.id} className={theme.style['Index.li']}>
+        <div key={mediator.summary.id} className={theme.style['Index.li']}>
           <button
             aria-label={mediator.word.title}
             className={theme.style['Index.button']}
@@ -113,9 +114,9 @@ function Index(): JSX.Element {
               <DeleteIcon />
             </button>
           )}
-        </li>
+        </div>
       ))}
-    </>
+    </VList>
   );
 }
 
@@ -187,9 +188,7 @@ export default function PrimarySidebar(): JSX.Element {
         ))}
       </select>
       <div className="grow overflow-auto">
-        <ul>
-          <Index />
-        </ul>
+        <Index />
       </div>
     </div>
   );


### PR DESCRIPTION
仮想ウィンドウを使用することで、表示されていない項目のレンダリングを防ぐことができます。
仮想ウィンドウをサポートする[virtua](https://github.com/inokawa/virtua)を導入したところ、スクリプティングが291 ms、レンダリングが28 msとなりました。
レンダリングの速度が1000倍以上になり、スクリプティングの速度は20倍以上になりました。
![image](https://github.com/skytomo221/otamajakushi-bookshelf/assets/18415838/a8d99dd9-c6a5-43fa-b34b-76e2e767c3c0)
